### PR TITLE
Ensure we're fetching the latest log file

### DIFF
--- a/PlexServiceCommon/LogWriter.cs
+++ b/PlexServiceCommon/LogWriter.cs
@@ -45,7 +45,7 @@ namespace PlexServiceCommon
         public static async Task<string> Read() {
             var log = string.Empty;
             var target = GetLatestLog();
-            if (target == string.Empty) return log;
+            if (string.IsNullOrEmpty(target)) return log;
             var count = 0;
             Log.Debug("Reading log to client...");
             while (count < 10) {

--- a/PlexServiceTray/NotifyIconApplicationContext.cs
+++ b/PlexServiceTray/NotifyIconApplicationContext.cs
@@ -473,7 +473,7 @@ namespace PlexServiceTray
             {
                 // If we're local to the service, just open the file.
                 if (sa is "127.0.0.1" or "0.0.0.0" or "localhost") {
-                    fileToOpen = _plexService?.GetLogPath() ?? LogWriter.LogFile;
+                    fileToOpen = _plexService?.GetLogPath();
                 } else {
                     Logger("Requesting log.");
                     // Otherwise, request the log data from the server, save it to a temp file, and open that.

--- a/PlexServiceWCF/TrayInteraction.cs
+++ b/PlexServiceWCF/TrayInteraction.cs
@@ -124,7 +124,7 @@ namespace PlexServiceWCF
         }
 
         public string GetLogPath() {
-            return LogWriter.LogFile;
+            return LogWriter.GetLatestLog();
         }
 
         public string GetPmsDataPath() {


### PR DESCRIPTION
As it can sometimes be days between log messages being written...ensure that we are returning a valid/most recent log file when reading/opening it.