### PR TITLE
PmsMonitor: Launch PMS with noautorestart param

### DIFF
--- a/PlexServiceWCF/PmsMonitor.cs
+++ b/PlexServiceWCF/PmsMonitor.cs
@@ -425,7 +425,7 @@ namespace PlexServiceWCF
                     else
                     {
                         Log.Information($"Plex Media Server version is {plexVersion}. Can use startup argument.");
-                        plexStartInfo.Arguments = "-noninteractive";
+                        plexStartInfo.Arguments = "-noninteractive -noautorestart";
                     }
                     _plex.StartInfo = plexStartInfo;
                     _plex.EnableRaisingEvents = true;


### PR DESCRIPTION
Starting with version 1.40.5 PMS supports the `noautorestart` command line param.  While it is 99.99% safe to kill PMS during maintenance tasks, there is a very small chance of database corruption and we'd rather be safe than sorry.  This new param will prevent PMS from starting itself after an auto update, instead allowing PMSService to start it.  This parameter is a no op in previous versions of PMS which eliminates the need for a version gate.